### PR TITLE
Replace nocoin-justdomains.txt with the original CoinBlockerLists

### DIFF
--- a/dns/unbound-plus/src/opnsense/scripts/OPNsense/Unboundplus/dnsbl.py
+++ b/dns/unbound-plus/src/opnsense/scripts/OPNsense/Unboundplus/dnsbl.py
@@ -49,7 +49,7 @@ predefined_lists = {
     "hpf": "https://hosts-file.net/fsa.txt",
     "hpp": "https://hosts-file.net/psh.txt",
     "hup": "https://hosts-file.net/pup.txt",
-    "nc": "https://justdomains.github.io/blocklists/lists/nocoin-justdomains.txt",
+    "cbl": "https://zerodot1.gitlab.io/CoinBlockerLists/hosts_browser",
     "rw": "https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt",
     "mw": "http://malwaredomains.lehigh.edu/files/justdomains",
     "pa": "https://raw.githubusercontent.com/chadmayfield/my-pihole-blocklists/master/lists/pi_blocklist_porn_all.list",


### PR DESCRIPTION
Hi @mimugmail,
I replaced the list because CoinBlockerLists are more up-to-date and contain some URLs more than other lists, and poor copies of CoinBlockerLists.

CoinBlockerLists Homepage: 
https://zerodot1.gitlab.io/CoinBlockerListsWeb/index.html

If necessary, there are also other lists on the homepage see:
https://zerodot1.gitlab.io/CoinBlockerListsWeb/downloads.html

If you have any questions please let [me](https://twitter.com/zero_dot1?lang=en) know.